### PR TITLE
Expose AbstractPolynomialHomotopy more

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,6 +32,8 @@ H(rand(Complex128, 2), 0.42)
 ## Homotopies
 
 The following homotopies are implemented
+### Polynomial homotopies
+These are subtypes of `AbstractPolynomialHomotopy`
 ```@docs
 StraightLineHomotopy
 GammaTrickHomotopy

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -51,7 +51,7 @@ Compute an inplace evaluation function `(u, x, t) -> u := ∂H∂t(x,t)` of the 
 function dt! end
 
 """
-    nvariables(H::AbstractHomotopy)
+    nvariables(H::AbstractPolynomialHomotopy)
 
 The number of variables which `H` expects as input, i.e. to evaluate `H(x,t)` `x` has to be a
 vector of length `nvariables(H)`.
@@ -59,7 +59,7 @@ vector of length `nvariables(H)`.
 function nvariables end
 
 """
-    homogenize(H::AbstractHomotopy)
+    homogenize(H::AbstractPolynomialHomotopy)
 
 Homogenize the homotopy `H`. This adds an additional variable.
 If `H` is already homogenized, this is the identity.
@@ -67,7 +67,7 @@ If `H` is already homogenized, this is the identity.
 function homogenize end
 
 """
-    dehomogenize(H::AbstractHomotopy)
+    dehomogenize(H::AbstractPolynomialHomotopy)
 
 Dehomogenize the homotopy `H`. This removes the first variable.
 If `H` is not homogenized, this is the identity.
@@ -75,14 +75,14 @@ If `H` is not homogenized, this is the identity.
 function dehomogenize end
 
 """
-    ishomogenized(H::AbstractHomotopy)
+    ishomogenized(H::AbstractPolynomialHomotopy)
 
 Check whether the homotopy `H` was homogenized.
 """
 function ishomogenized end
 
 """
-    ishomogenous(H::AbstractHomotopy)
+    ishomogenous(H::AbstractPolynomialHomotopy)
 
 Check whether the homotopy `H` is homogenous. This does not imply that `H` was homogenized.
 """

--- a/src/randomhomotopy.jl
+++ b/src/randomhomotopy.jl
@@ -1,7 +1,7 @@
 export randomhomotopy, randomsystem
 
 """
-    randomhomotopy(::Type{AbstractHomotopy{T}}, size::Int; kwargs...)
+    randomhomotopy(::Type{AbstractPolynomialHomotopy{T}}, size::Int; kwargs...)
 
 Create a total degree homotopy where the target system is a [`randomsystem(T, size, size; kwargs...)`](@ref).
 
@@ -14,11 +14,11 @@ julia> nvariables(H)
 3
 ```
 """
-function randomhomotopy(H::Type{<:AbstractHomotopy{T}}, size::Int; kwargs...) where {T<:Complex}
+function randomhomotopy(H::Type{<:AbstractPolynomialHomotopy{T}}, size::Int; kwargs...) where {T<:Complex}
     F = randomsystem(T, size, size; kwargs...)
     totaldegree(H, F)
 end
-function randomhomotopy(H::Type{<:AbstractHomotopy}, size::Int; kwargs...)
+function randomhomotopy(H::Type{<:AbstractPolynomialHomotopy}, size::Int; kwargs...)
     F = randomsystem(size, size; kwargs...)
     totaldegree(H, F)
 end

--- a/src/totaldegree.jl
+++ b/src/totaldegree.jl
@@ -41,7 +41,7 @@ Base.length(iter::TotalDegreeSolutionIterator) = length(iter.iterator)
 Base.eltype(iter::TotalDegreeSolutionIterator{T}) where {T} = Vector{T}
 
 """
-    totaldegree(H::Type{AbstractHomotopy}, F, [unitroots=false])
+    totaldegree(H::Type{AbstractPolynomialHomotopy}, F, [unitroots=false])
 
 Construct a  total degree homotopy of type `H` with `F` and an iterator of its solutions.
 This is the homotopy with start system
@@ -62,16 +62,16 @@ complex number (with real and imaginary part in the unit interval).
 H, startsolutions = totaldegree(StraightLineHomotopy{Complex128}, [x^2+y+1, x^3*y-2])
 ```
 """
-function totaldegree(H::Type{<:AbstractHomotopy{T}}, fs::Vector{<:MP.AbstractPolynomial{U}}; kwargs...) where {T<:Complex, U<:Number}
+function totaldegree(H::Type{<:AbstractPolynomialHomotopy{T}}, fs::Vector{<:MP.AbstractPolynomial{U}}; kwargs...) where {T<:Complex, U<:Number}
     F = convert(Vector{FP.Polynomial{T}}, fs)
     totaldegree(H, F; kwargs...)
 end
-function totaldegree(H::Type{<:AbstractHomotopy}, fs::Vector{<:MP.AbstractPolynomial{U}}; kwargs...) where {U<:Number}
+function totaldegree(H::Type{<:AbstractPolynomialHomotopy}, fs::Vector{<:MP.AbstractPolynomial{U}}; kwargs...) where {U<:Number}
     F = convert(Vector{FP.Polynomial{promote_type(Complex128, U)}}, fs)
     totaldegree(H, F; kwargs...)
 end
 
-function totaldegree(H::Type{<:AbstractHomotopy}, F::Vector{FP.Polynomial{U}}; kwargs...) where {U<:Number}
+function totaldegree(H::Type{<:AbstractPolynomialHomotopy}, F::Vector{FP.Polynomial{U}}; kwargs...) where {U<:Number}
     G, solutions = totaldegree_startsystem(F; kwargs...)
     H(G, F), solutions
 end


### PR DESCRIPTION
`StraightLineHomotopy` and `GammaTrickHomotopy` are an subtype of `AbstractPolynomialHomotopy`. This PR makes this clearer in the docs and also makes the interface more restrictive.

I think this is beneficial if we later add more general, i.e. non-polynomial, homotopies.